### PR TITLE
`anchorSpace` does not have to be nullable anymore

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -139,7 +139,7 @@ XRAnchor {#xr-anchor}
 <script type="idl">
 [SecureContext, Exposed=Window]
 interface XRAnchor {
-  readonly attribute XRSpace? anchorSpace;
+  readonly attribute XRSpace anchorSpace;
 
   void detach();
 };


### PR DESCRIPTION
Fix omission from previous PR.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/immersive-web/anchors/pull/33.html" title="Last updated on Mar 2, 2020, 7:37 PM UTC (038c3db)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/immersive-web/anchors/33/049fb23...038c3db.html" title="Last updated on Mar 2, 2020, 7:37 PM UTC (038c3db)">Diff</a>