### PR TITLE
Fix typo for createAnchor API interface

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -171,7 +171,7 @@ The {{XRSession}} is extended to contain an associated <dfn for=XRSession>set of
 The {{XRSession}} is extended to contain an associated <dfn for=XRSession>map of new anchors</dfn> that is keyed with {{XRAnchor}} object and maps to <code>{{Promise}}&lt;{{XRAnchor}}&gt;</code> object.
 
 <script type="idl">
-partial interface XRFrame {
+partial interface XRSession {
   Promise<XRAnchor> createAnchor(XRRigidTransform pose, XRSpace space);
 };
 


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/raviramachandra/anchors/pull/38.html" title="Last updated on Apr 17, 2020, 5:56 PM UTC (e2111c9)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/immersive-web/anchors/38/59d0c3e...raviramachandra:e2111c9.html" title="Last updated on Apr 17, 2020, 5:56 PM UTC (e2111c9)">Diff</a>