### PR TITLE
Add accidentally omitted returns in createAnchor() algorithms

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -201,6 +201,7 @@ The {{XRFrame/createAnchor(pose, space)}} method, when invoked on an {{XRFrame}}
     1. [=Create new anchor object=] |anchor| using |anchor native origin| and |session|.
     1. Add |anchor| to |session|'s [=XRSession/set of tracked anchors=].
     1. Add a mapping from |anchor| to |promise| to |session|'s [=XRSession/map of new anchors=].
+    1. Return |promise|.
 </div>
 
 Note: It is the responsibility of user agents to ensure that the physical origin tracked by the anchor returned by each {{XRFrame/createAnchor(pose, space)}} call aligns as closely as possible with the physical location of |pose| within |space| at the time represented by the frame on which the method is called. Specifically, this means that for spaces that are dynamically changing, user agents should attempt to capture the native origin of such spaces at the app's specified time. This text is non-normative, but expresses the intent of the specification author(s) and contributors and thus it is highly recommended that it is followed by the implementations to ensure consistent behavior across different vendors.
@@ -220,6 +221,7 @@ The {{XRHitTestResult/createAnchor(pose)}} method, when invoked on an {{XRHitTes
     1. [=Create new anchor object=] |anchor| using |anchor native origin| and |session|.
     1. Add |anchor| to |session|'s [=XRSession/set of tracked anchors=].
     1. Add a mapping from |anchor| to |promise| to |session|'s [=XRSession/map of new anchors=].
+    1. Return |promise|.
 </div>
 
 Note: The same remark that is present on {{XRFrame/createAnchor(pose, space)}} method applies here as well.


### PR DESCRIPTION
Related to issue #44.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/immersive-web/anchors/pull/45.html" title="Last updated on May 30, 2020, 12:21 AM UTC (9dc9df1)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/immersive-web/anchors/45/82d19af...9dc9df1.html" title="Last updated on May 30, 2020, 12:21 AM UTC (9dc9df1)">Diff</a>