### PR TITLE
fix "unstable" css style for light mode

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -90,7 +90,7 @@ spec: WebXR Hit Test Module; urlPrefix: https://immersive-web.github.io/hit-test
     border-radius: .5em;
     padding: .5em;
     margin: .5em calc(-0.5em - 1px);
-    background-image: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' width='300' height='290'><text transform='rotate(-45)' text-anchor='middle' font-family='sans-serif' font-weight='bold' font-size='70' y='210' opacity='.1'>Unstable</text></svg>");
+    background-image: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' width='300' height='290'><text transform='rotate(-45)' text-anchor='middle' font-family='sans-serif' font-weight='bold' font-size='70' y='210' opacity='.1' fill='white'>Unstable</text></svg>");
     background-repeat: repeat;
     background-color: #282828;
   }

--- a/index.bs
+++ b/index.bs
@@ -94,6 +94,12 @@ spec: WebXR Hit Test Module; urlPrefix: https://immersive-web.github.io/hit-test
     background-repeat: repeat;
     background-color: #282828;
   }
+  @media (prefers-color-scheme: light) {
+    .unstable {
+      background-image: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' width='300' height='290'><text transform='rotate(-45)' text-anchor='middle' font-family='sans-serif' font-weight='bold' font-size='70' y='210' opacity='.1'>Unstable</text></svg>");
+      background-color: #FFF4F4;
+    }
+  }
   .unstable h3:first-of-type {
     margin-top: 0.5rem;
   }


### PR DESCRIPTION
otherwise unstable sections are unreadable in light mode.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/cabanier/anchors/pull/77.html" title="Last updated on Sep 20, 2022, 6:52 PM UTC (f91dd62)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/immersive-web/anchors/77/44f8731...cabanier:f91dd62.html" title="Last updated on Sep 20, 2022, 6:52 PM UTC (f91dd62)">Diff</a>