### PR TITLE
Fix Session ended and UUID RFC link errors

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -30,6 +30,7 @@ spec: WebXR Device API - Level 1; urlPrefix: https://www.w3.org/TR/webxr/#
         type: dfn; text: session; url: dom-xrframe-session
         type: dfn; text: time; url: xrframe-time
     for: XRSession;
+        type: attribute; text: ended; url: xrsession-ended
         type: dfn; text: list of frame updates; url: xrsession-list-of-frame-updates
         type: dfn; text: mode; url: xrsession-mode
         type: dfn; text: XR device; url: xrsession-xr-device
@@ -184,7 +185,7 @@ The {{XRAnchor/requestPersistentHandle()}} method, when invoked on an {{XRAnchor
         1. Return |promise|.
         1. Abort these steps.
     1. Let |uuid| be the empty string.
-    1. Generate a UUID [[!RFC4122]] as a string and append it to |uuid|.
+    1. Generate a UUID [[!RFC9562]] as a string and append it to |uuid|.
     1. Add |uuid| and |anchor| to |session|'s [=XRSession/map of persistent anchors=].
     1. [=/Resolve=] |promise| with |uuid|.
     1. Return |promise|.
@@ -255,7 +256,7 @@ Note: It is the responsibility of user agents to ensure that the physical origin
 The {{XRSession/restorePersistentAnchor(uuid)}} method, when invoked on an {{XRSession}} |session| with |uuid|, MUST run the following steps:
     1. Let |promise| be [=a new Promise=] in the [=relevant realm=] of this {{XRSystem}}.
     1. If |session|'s [=XRSession/map of persistent anchors=] does not contain a mapping from |uuid| to an {{XRAnchor}}, [=/reject=] |promise| with {{InvalidStateError}}, return |promise|, and abort these steps.
-    1. If |session|’s [=ended=] value is `true`, [=/reject=] |promise| with {{InvalidStateError}}, return |promise|, and abort these steps.
+    1. If |session|’s {{XRSession/ended}} value is `true`, [=/reject=] |promise| with {{InvalidStateError}}, return |promise|, and abort these steps.
     1. Let |anchor| be the value of mapping from |uuid| on |session|'s [=XRSession/map of persistent anchors=].
     1. If |session|'s [=XRSession/map of new anchors=] contains a mapping from |anchor| to |promise|, [=/reject=] the |promise| with {{InvalidStateError}}, return |promise|, and abort these steps.
     1. Add |anchor| to |session|'s [=XRSession/set of tracked anchors=].


### PR DESCRIPTION
Update [=ended=] (which actually links to a CSS spec), to link to XRSession/ended.

Also updates the link to UUID to the more recent standards track RFC, per the link errors. I believe this may technically introduce more versions of UUID that are allowed, but given that the intention is that it's basically just an opaque handle/unique identifier to be passed from and to the same user agent, I don't think this is problematic. If we feel it is, we can also explicitly reference the obsoleted version with an acknowledgement that it's obsoleted to suppress the error.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/immersive-web/anchors/pull/86.html" title="Last updated on Dec 11, 2025, 7:51 PM UTC (cb57c0e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/immersive-web/anchors/86/cc161a2...cb57c0e.html" title="Last updated on Dec 11, 2025, 7:51 PM UTC (cb57c0e)">Diff</a>