### PR TITLE
Clarify that map of persistent anchors is per-origin

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -50,6 +50,8 @@ spec: WebXR Hit Test Module; urlPrefix: https://immersive-web.github.io/hit-test
         type: dfn; text: frame; url: xrhittestresult-frame
         type: dfn; text: native origin; url: xrhittestresult-native-origin
     type: dfn; text: hit-test; url: hit-test
+spec:html; urlPrefix: https://html.spec.whatwg.org/multipage/
+    type: dfn; text: origin; url: origin.html#concept-origin
 </pre>
 
 <style>
@@ -201,6 +203,7 @@ The {{XRSession}} is extended to contain an associated <dfn for=XRSession>set of
 <div class="unstable">
 
 The {{XRSession}} is extended to contain an associated <dfn for=XRSession>map of persistent anchors</dfn> that is keyed with a UUID string and maps to an {{XRAnchor}}.
+This map is populated and stored by the [=XRSession/XR device=] and restricted to only the set of persistent anchors created and not yet destroyed by any {{XRSession}} on [=origin=].
 The size of this map is determined by the user agent. The user agent MAY delete entries from this map for any reason. For instance, if the maximum number of system anchors
 is reached for all maps for all origins, the user agent MAY free up an entry to make space for the newly requested anchor.
 


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/immersive-web/anchors/pull/88.html" title="Last updated on Mar 24, 2026, 9:49 PM UTC (429cdc6)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/immersive-web/anchors/88/dafcb70...429cdc6.html" title="Last updated on Mar 24, 2026, 9:49 PM UTC (429cdc6)">Diff</a>